### PR TITLE
Assume next state

### DIFF
--- a/custom_components/purei9/vacuum.py
+++ b/custom_components/purei9/vacuum.py
@@ -1,5 +1,4 @@
 """Home Assistant vacuum entity"""
-from datetime import timedelta
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
 from homeassistant.helpers.entity import DeviceInfo
@@ -113,7 +112,8 @@ class PureI9(StateVacuumEntity):
 
     @property
     def assumed_state(self) -> bool:
-        return self._assumed_next_state != None
+        """Assume the next state after sending a command"""
+        return self._assumed_next_state is not None
 
     def start(self) -> None:
         """Start cleaning"""

--- a/custom_components/purei9/vacuum.py
+++ b/custom_components/purei9/vacuum.py
@@ -21,13 +21,6 @@ from homeassistant.const import CONF_PASSWORD, CONF_EMAIL
 from purei9_unofficial.cloud import CloudClient, CloudRobot
 from . import purei9, const
 
-# The default scan interval is 15 seconds.
-# Tweak this until we feel that we have a good value
-# that updates statuses asap, but without having the fetch
-# unnecessary intermediate states
-# See: https://developers.home-assistant.io/docs/integration_fetching_data/
-SCAN_INTERVAL = timedelta(seconds=20)
-
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_EMAIL): cv.string,
     vol.Required(CONF_PASSWORD): cv.string

--- a/custom_components/purei9/vacuum.py
+++ b/custom_components/purei9/vacuum.py
@@ -148,7 +148,7 @@ class PureI9(StateVacuumEntity):
         Called by Home Assistant asking the vacuum to update to the latest state.
         Can contain IO code.
         """
-        if self._assumed_next_state != None:
+        if self._assumed_next_state is not None:
             self._params.state = self._assumed_next_state
             self._assumed_next_state = None
         else:


### PR DESCRIPTION
There's a delay between sending a command and polling data from the Pure i9. When we send a command, the next poll will report the old state. It's a shame because the Pure i9 will respond with the "next state" in the API call of the send command, but `purei9_unofficial` does not take that into account. If we'd just read the response we'd get the next proper state.

Therefore, for now, until the Pure i9 API code has been updated, we'll assume that whatever command we send will be successful and we'll assume the state. This works fine unless you're hammering the start, pause, stop, return to dock buttons back-and-forth. But after all it's just an assumed state so that can be considered an error margin.