### PR TITLE
Polish to power modes

### DIFF
--- a/custom_components/purei9/purei9.py
+++ b/custom_components/purei9/purei9.py
@@ -52,12 +52,8 @@ def battery_to_hass(pure_i9_battery: str) -> int:
     """Translate Pure i9 data into a Home Assistant battery level"""
     return PURE_I9_BATTERY_MAP.get(pure_i9_battery, 0)
 
-# Should not be specifically disabling properties.
-# Rewrite this class as a TypedDict instead.
-# pylint: disable=too-few-public-methods
 class Params:
     """Data available in the state"""
-    name: str
     battery: int = 100
     state: str = STATE_IDLE
     available: bool = True

--- a/custom_components/purei9/purei9.py
+++ b/custom_components/purei9/purei9.py
@@ -1,5 +1,6 @@
 """Pure i9 business logic"""
 from typing import List
+from enum import Enum
 from purei9_unofficial.common import BatteryStatus, RobotStates, PowerMode
 from homeassistant.components.vacuum import (
     STATE_CLEANING,
@@ -74,3 +75,27 @@ class Params:
     def fan_speed_list(self) -> str:
         """Immutable fan speed list"""
         return self._fan_speed_list
+
+class PowerModes(Enum):
+    ECO = "eco"
+    POWER = "power"
+    QUIET = "quiet"
+    SMART = "smart"
+
+def is_power_mode_v2(fan_speed_list: List[str]) -> bool:
+    """Determine if the robot supports the new or old fan speed list """
+    return len(fan_speed_list) == 3
+
+def fan_speed_list_to_hass(fan_speed_list_purei9: List[str]) -> List[PowerModes]:
+    """Convert the fan speed list to internal representation"""
+    return list([PowerModes.QUIET, PowerModes.SMART, PowerModes.POWER] if is_power_mode_v2(fan_speed_list_purei9) else [PowerModes.ECO, PowerModes.POWER])
+
+def fan_speed_list_to_purei9(fan_speed_hass: PowerModes) -> List[str]:
+    if fan_speed_hass == PowerModes.POWER:
+        return PowerMode.HIGH
+
+    if fan_speed_hass == PowerModes.SMART:
+        return PowerMode.MEDIUM
+
+    return PowerMode.LOW
+

--- a/custom_components/purei9/purei9.py
+++ b/custom_components/purei9/purei9.py
@@ -109,8 +109,7 @@ def fan_speed_to_hass(fan_speed_list: List[str], fan_speed_purei9: PowerMode) ->
 
         if fan_speed_purei9 == PowerMode.MEDIUM:
             return POWER_MODE_SMART
-
-    if fan_speed_purei9 == PowerMode.MEDIUM:
+    else if fan_speed_purei9 == PowerMode.MEDIUM:
         return POWER_MODE_ECO
 
     return POWER_MODE_POWER

--- a/custom_components/purei9/purei9.py
+++ b/custom_components/purei9/purei9.py
@@ -109,7 +109,7 @@ def fan_speed_to_hass(fan_speed_list: List[str], fan_speed_purei9: PowerMode) ->
 
         if fan_speed_purei9 == PowerMode.MEDIUM:
             return POWER_MODE_SMART
-    else if fan_speed_purei9 == PowerMode.MEDIUM:
+    elif fan_speed_purei9 == PowerMode.MEDIUM:
         return POWER_MODE_ECO
 
     return POWER_MODE_POWER

--- a/custom_components/purei9/vacuum.py
+++ b/custom_components/purei9/vacuum.py
@@ -20,7 +20,6 @@ from homeassistant.components.vacuum import (
 )
 from homeassistant.const import CONF_PASSWORD, CONF_EMAIL
 from purei9_unofficial.cloudv2 import CloudClient, CloudRobot
-from purei9_unofficial.common import PowerMode
 from . import purei9, const
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -46,11 +45,15 @@ class PureI9(StateVacuumEntity):
         # The Pure i9 library caches results. When we do state updates, the next update
         # is sometimes cached. Override that so we can get the desired state quicker.
         self._assumed_next_state = None
+        # Used to save a fan speed switch
+        self._next_fan_speed: str = None
 
     @staticmethod
     def create(robot: CloudRobot):
         """Named constructor for creating a new instance from a CloudRobot"""
-        fan_speed_list = purei9.fan_speed_list_to_hass(list(map(lambda x: x.name, robot.getsupportedpowermodes())))
+        purei9_fan_speed_list = list(map(lambda x: x.name, robot.getsupportedpowermodes()))
+        fan_speed_list = purei9.fan_speed_list_to_hass(purei9_fan_speed_list)
+
         params = purei9.Params(robot.getid(), robot.getname(), fan_speed_list)
         return PureI9(robot, params)
 
@@ -166,24 +169,31 @@ class PureI9(StateVacuumEntity):
 
     def set_fan_speed(self, fan_speed: str, **kwargs: Any) -> None:
         """Set the fan speed of the robot"""
-        self._params.fan_speed = fan_speed
+        self._next_fan_speed = fan_speed.upper()
 
     def update(self) -> None:
         """
         Called by Home Assistant asking the vacuum to update to the latest state.
         Can contain IO code.
         """
+        pure_i9_battery = self._robot.getbattery()
+
         if self._assumed_next_state is not None:
             self._params.state = self._assumed_next_state
             self._assumed_next_state = None
         else:
-            pure_i9_battery = self._robot.getbattery()
-
-            self._robot.setpowermode(purei9.fan_speed_list_to_purei9(self._params.fan_speed))
-
-            self._params.name = self._robot.getname()
-            self._params.battery = purei9.battery_to_hass(pure_i9_battery)
             self._params.state = purei9.state_to_hass(self._robot.getstatus(), pure_i9_battery)
-            self._params.available = self._robot.isconnected()
-            self._params.firmware = self._robot.getfirmware()
-            self._params.fan_speed = self._robot.getpowermode().name
+
+        if self._next_fan_speed is not None:
+            self._robot.setpowermode(purei9.fan_speed_to_purei9(self._next_fan_speed))
+            self._params.fan_speed = self._next_fan_speed
+            self._next_fan_speed = None
+        else:
+            # Do not get the fan speed if we just updated. We might fetch an older value.
+            self._params.fan_speed = purei9.fan_speed_to_hass(
+                self._params.fan_speed_list, self._robot.getpowermode())
+
+        self._params.name = self._robot.getname()
+        self._params.battery = purei9.battery_to_hass(pure_i9_battery)
+        self._params.available = self._robot.isconnected()
+        self._params.firmware = self._robot.getfirmware()

--- a/custom_components/purei9/vacuum.py
+++ b/custom_components/purei9/vacuum.py
@@ -50,7 +50,7 @@ class PureI9(StateVacuumEntity):
     @staticmethod
     def create(robot: CloudRobot):
         """Named constructor for creating a new instance from a CloudRobot"""
-        fan_speed_list = list(map(lambda x: x.name, robot.getsupportedpowermodes()))
+        fan_speed_list = purei9.fan_speed_list_to_hass(list(map(lambda x: x.name, robot.getsupportedpowermodes())))
         params = purei9.Params(robot.getid(), robot.getname(), fan_speed_list)
         return PureI9(robot, params)
 
@@ -179,7 +179,7 @@ class PureI9(StateVacuumEntity):
         else:
             pure_i9_battery = self._robot.getbattery()
 
-            self._robot.setpowermode(PowerMode[self._params.fan_speed])
+            self._robot.setpowermode(purei9.fan_speed_list_to_purei9(self._params.fan_speed))
 
             self._params.name = self._robot.getname()
             self._params.battery = purei9.battery_to_hass(pure_i9_battery)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 purei9_unofficial==0.0.7
-homeassistant==2021.8.8
+homeassistant==2021.11.5
 pylint==2.10.2

--- a/tests/test_purei9.py
+++ b/tests/test_purei9.py
@@ -67,8 +67,14 @@ class TestPureI9(unittest.TestCase):
                 self.assertEqual(expected, purei9.is_power_mode_v2(fan_speed_list))
 
     data_fan_speed_list_to_hass = [
-        (list([PowerMode.LOW, PowerMode.HIGH]), list([purei9.PowerModes.ECO, purei9.PowerModes.POWER])),
-        (list([PowerMode.LOW, PowerMode.MEDIUM, PowerMode.HIGH]), list([purei9.PowerModes.QUIET, purei9.PowerModes.SMART, purei9.PowerModes.POWER])),
+        (
+            list([PowerMode.LOW, PowerMode.HIGH]),
+            list([purei9.POWER_MODE_ECO, purei9.POWER_MODE_POWER])
+        ),
+        (
+            list([PowerMode.LOW, PowerMode.MEDIUM, PowerMode.HIGH]),
+            list([purei9.POWER_MODE_QUIET, purei9.POWER_MODE_SMART, purei9.POWER_MODE_POWER])
+        ),
     ]
 
     def test_fan_speed_list_to_hass(self):
@@ -77,18 +83,31 @@ class TestPureI9(unittest.TestCase):
             with self.subTest():
                 self.assertEqual(expected, purei9.fan_speed_list_to_hass(fan_speed_list))
 
-    data_fan_speed_list_to_purei9 = [
-        (purei9.PowerModes.ECO, PowerMode.LOW),
-        (purei9.PowerModes.QUIET, PowerMode.LOW),
-        (purei9.PowerModes.SMART, PowerMode.MEDIUM),
-        (purei9.PowerModes.POWER, PowerMode.HIGH),
+    data_fan_speed_to_purei9 = [
+        (purei9.POWER_MODE_ECO, PowerMode.MEDIUM),
+        (purei9.POWER_MODE_QUIET, PowerMode.LOW),
+        (purei9.POWER_MODE_SMART, PowerMode.MEDIUM),
+        (purei9.POWER_MODE_POWER, PowerMode.HIGH),
     ]
 
-    def test_fan_speed_list_to_purei9(self):
+    def test_fan_speed_to_purei9(self):
         """Test to convert a fan speed value back to Purei9 integration format"""
-        for fan_speed, expected in self.data_fan_speed_list_to_purei9:
+        for fan_speed, expected in self.data_fan_speed_to_purei9:
             with self.subTest():
-                self.assertEqual(expected, purei9.fan_speed_list_to_purei9(fan_speed))
+                self.assertEqual(expected, purei9.fan_speed_to_purei9(fan_speed))
+
+    data_fan_speed_to_hass = [
+        (list([1, 2]), PowerMode.MEDIUM, purei9.POWER_MODE_ECO),
+        (list([1, 2, 3]), PowerMode.LOW, purei9.POWER_MODE_QUIET),
+        (list([1, 2, 3]), PowerMode.MEDIUM, purei9.POWER_MODE_SMART),
+        (list([1, 2]), PowerMode.HIGH, purei9.POWER_MODE_POWER),
+    ]
+
+    def test_fan_speed_to_hass(self):
+        """Test to convert a fan speed value back to Purei9 integration format"""
+        for fan_speed_list, fan_speed, expected in self.data_fan_speed_to_hass:
+            with self.subTest():
+                self.assertEqual(expected, purei9.fan_speed_to_hass(fan_speed_list, fan_speed))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_purei9.py
+++ b/tests/test_purei9.py
@@ -55,5 +55,40 @@ class TestPureI9(unittest.TestCase):
         params.name = new_name
         self.assertEqual(new_name, params.name)
 
+    data_is_power_mode_v2 = [
+        (list([1, 2, 3]), True),
+        (list([1, 2]), False),
+    ]
+
+    def test_is_power_mode_v2(self):
+        """Test if the power mode is v2 or not"""
+        for fan_speed_list, expected in self.data_is_power_mode_v2:
+            with self.subTest():
+                self.assertEqual(expected, purei9.is_power_mode_v2(fan_speed_list))
+
+    data_fan_speed_list_to_hass = [
+        (list([PowerMode.LOW, PowerMode.HIGH]), list([purei9.PowerModes.ECO, purei9.PowerModes.POWER])),
+        (list([PowerMode.LOW, PowerMode.MEDIUM, PowerMode.HIGH]), list([purei9.PowerModes.QUIET, purei9.PowerModes.SMART, purei9.PowerModes.POWER])),
+    ]
+
+    def test_fan_speed_list_to_hass(self):
+        """Test to convert the fan speed list to a format used by the integration"""
+        for fan_speed_list, expected in self.data_fan_speed_list_to_hass:
+            with self.subTest():
+                self.assertEqual(expected, purei9.fan_speed_list_to_hass(fan_speed_list))
+
+    data_fan_speed_list_to_purei9 = [
+        (purei9.PowerModes.ECO, PowerMode.LOW),
+        (purei9.PowerModes.QUIET, PowerMode.LOW),
+        (purei9.PowerModes.SMART, PowerMode.MEDIUM),
+        (purei9.PowerModes.POWER, PowerMode.HIGH),
+    ]
+
+    def test_fan_speed_list_to_purei9(self):
+        """Test to convert a fan speed value back to Purei9 integration format"""
+        for fan_speed, expected in self.data_fan_speed_list_to_purei9:
+            with self.subTest():
+                self.assertEqual(expected, purei9.fan_speed_list_to_purei9(fan_speed))
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Set names for power modes with accordance to the app. I.e. for older Purei9s they should have "Eco" and "Power" mode available. For newer, "Quiet", "Smart" and "Power".