### PR TITLE
Update purei9_unofficial to 0.0.10

### DIFF
--- a/custom_components/purei9/manifest.json
+++ b/custom_components/purei9/manifest.json
@@ -6,7 +6,7 @@
     "issue_tracker": "https://github.com/Ekman/home-assistant-pure-i9/issues",
     "dependencies": [],
     "codeowners": ["Ekman"],
-    "requirements": ["purei9_unofficial==0.0.8"],
+    "requirements": ["purei9_unofficial==0.0.10"],
     "iot_class": "cloud_polling",
     "config_flow": false
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-purei9_unofficial==0.0.8
+purei9_unofficial==0.0.10
 homeassistant==2021.11.5
 pylint==2.10.2


### PR DESCRIPTION
Needed to use v2 of the API, v1 fails to authenticate.