### PR TITLE
Update V3 API from purei9_unofficial

### DIFF
--- a/custom_components/purei9/__init__.py
+++ b/custom_components/purei9/__init__.py
@@ -1,7 +1,7 @@
 """Control your Electrolux Purei9 vacuum robot"""
 import asyncio
 from homeassistant.const import CONF_PASSWORD, CONF_EMAIL
-from purei9_unofficial.cloudv2 import CloudClient
+from purei9_unofficial.cloudv3 import CloudClient
 from . import const, coordinator
 
 PLATFORMS = ["vacuum", "sensor"]

--- a/custom_components/purei9/config_flow.py
+++ b/custom_components/purei9/config_flow.py
@@ -2,7 +2,7 @@
 import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
-from purei9_unofficial.cloudv2 import CloudClient
+from purei9_unofficial.cloudv3 import CloudClient
 from .const import DOMAIN
 
 class HiveOsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):

--- a/custom_components/purei9/manifest.json
+++ b/custom_components/purei9/manifest.json
@@ -1,12 +1,12 @@
 {
     "domain": "purei9",
     "name": "Pure i9",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "documentation": "https://github.com/Ekman/home-assistant-pure-i9",
     "issue_tracker": "https://github.com/Ekman/home-assistant-pure-i9/issues",
     "dependencies": [],
     "codeowners": ["Ekman"],
-    "requirements": ["purei9_unofficial==0.0.11"],
+    "requirements": ["purei9_unofficial==0.0.12"],
     "iot_class": "cloud_polling",
     "config_flow": true
 }

--- a/custom_components/purei9/vacuum.py
+++ b/custom_components/purei9/vacuum.py
@@ -21,7 +21,7 @@ from homeassistant.components.vacuum import (
 )
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.const import CONF_PASSWORD, CONF_EMAIL
-from purei9_unofficial.cloudv2 import CloudClient, CloudRobot
+from purei9_unofficial.cloudv3 import CloudClient, CloudRobot
 from . import purei9, const
 
 _LOGGER = logging.getLogger(__name__)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-purei9_unofficial==0.0.11
+purei9_unofficial==0.0.12
 homeassistant==2021.11.5
 pylint==2.10.2


### PR DESCRIPTION
With my AEG RX9-2 I had been having problems with cloud integration for a few weeks.
So I upgraded the API to version 3, available with purei9_unofficial==0.0.12, now it works properly.